### PR TITLE
[Repo Assist] fix(tsconfig): remove deprecated baseUrl option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "outDir": "dist",
-    "baseUrl": ".",
     "paths": {
-      "@shared/*": ["src/shared/*"]
+      "@shared/*": ["./src/shared/*"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
TypeScript 5.9 deprecated the 'baseUrl' option when used solely for path mapping (TS5101). With 'moduleResolution: bundler', paths entries can be written relative to the tsconfig file location, making baseUrl unnecessary.

Update '@shared/*' paths entry to use './src/shared/*' to resolve correctly without baseUrl.