### PR TITLE
[Repo Assist] refactor(renderer): extract shared sanitizeHtml utility

### DIFF
--- a/src/renderer/components/AutomationsList.tsx
+++ b/src/renderer/components/AutomationsList.tsx
@@ -18,16 +18,9 @@ import {
 } from '@primer/octicons-react'
 import { marked } from 'marked'
 import { RepoWorkflow, RepoRun } from '@shared/types'
+import { sanitizeHtml } from '../utils/sanitize'
 
 marked.setOptions({ gfm: true, breaks: true })
-
-function sanitizeHtml(html: string): string {
-  return html
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/\bon\w+\s*=\s*["'][^"']*["']/gi, '')
-    .replace(/\bon\w+\s*=\s*[^\s>]*/gi, '')
-    .replace(/javascript:/gi, '')
-}
 
 interface AutomationsListProps {
   repo: string

--- a/src/renderer/components/DetailPanel.tsx
+++ b/src/renderer/components/DetailPanel.tsx
@@ -24,6 +24,7 @@ import {
 } from '@primer/octicons-react'
 import { marked } from 'marked'
 import { IssueDetail, PRDetail, PRCheck, PRTimelineEvent, PRBranchStatus } from '@shared/types'
+import { sanitizeHtml } from '../utils/sanitize'
 
 /** Wrapper around RelativeTime that guards against invalid dates */
 function SafeRelativeTime({ date, ...props }: { date: Date; style?: React.CSSProperties }) {
@@ -36,15 +37,6 @@ marked.setOptions({
   gfm: true,
   breaks: true,
 })
-
-/** Sanitize HTML by stripping script tags and event handlers */
-function sanitizeHtml(html: string): string {
-  return html
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/\bon\w+\s*=\s*["'][^"']*["']/gi, '')
-    .replace(/\bon\w+\s*=\s*[^\s>]*/gi, '')
-    .replace(/javascript:/gi, '')
-}
 
 /** Render markdown to sanitized HTML; converts #N to in-app links */
 function renderMarkdown(md: string, repo?: string): string {

--- a/src/renderer/components/RecapPanel.tsx
+++ b/src/renderer/components/RecapPanel.tsx
@@ -8,16 +8,9 @@ import {
 } from '@primer/octicons-react'
 import { marked } from 'marked'
 import { RecapSummary } from '@shared/types'
+import { sanitizeHtml } from '../utils/sanitize'
 
 marked.setOptions({ gfm: true, breaks: true })
-
-function sanitizeHtml(html: string): string {
-  return html
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/\bon\w+\s*=\s*["'][^"']*["']/gi, '')
-    .replace(/\bon\w+\s*=\s*[^\s>]*/gi, '')
-    .replace(/javascript:/gi, '')
-}
 
 interface RecapPanelProps {
   repos: string[]

--- a/src/renderer/utils/sanitize.ts
+++ b/src/renderer/utils/sanitize.ts
@@ -1,0 +1,8 @@
+/** Strip dangerous HTML from user-authored content before rendering with dangerouslySetInnerHTML. */
+export function sanitizeHtml(html: string): string {
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/\bon\w+\s*=\s*["'][^"']*["']/gi, '')
+    .replace(/\bon\w+\s*=\s*[^\s>]*/gi, '')
+    .replace(/javascript:/gi, '')
+}


### PR DESCRIPTION
The sanitizeHtml function (strips <script> tags, event handler attributes, and javascript: URLs) was duplicated identically in AutomationsList.tsx, RecapPanel.tsx, and DetailPanel.tsx.

Extract it to src/renderer/utils/sanitize.ts and update all three components to import from there. No behavioural change.