### PR TITLE
[Repo Assist] chore(deps): bundle minor/patch dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,23 +14,23 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@primer/octicons-react": "^19.22.0",
+    "@primer/octicons-react": "^19.24.0",
     "@primer/primitives": "^11.5.1",
-    "@primer/react": "^38.15.0",
-    "electron": "^41.0.2",
+    "@primer/react": "^38.19.0",
+    "electron": "^41.2.0",
     "electron-vite": "^5.0.0",
-    "marked": "^17.0.4",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "react-is": "^19.2.4",
-    "styled-components": "^6.3.11",
-    "vite": "^7.3.1"
+    "marked": "^17.0.6",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "react-is": "^19.2.5",
+    "styled-components": "^6.4.0",
+    "vite": "^7.3.2"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.7.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.4"
   }
 }


### PR DESCRIPTION
Minor/patch version bumps for all relevant packages:

- @primer/octicons-react: ^19.22.0 → ^19.24.0
- @primer/react: ^38.15.0 → ^38.19.0
- electron: ^41.0.2 → ^41.2.0
- marked: ^17.0.4 → ^17.0.6
- react: ^19.2.4 → ^19.2.5
- react-dom: ^19.2.4 → ^19.2.5
- react-is: ^19.2.4 → ^19.2.5
- styled-components: ^6.3.11 → ^6.4.0
- vite: ^7.3.1 → ^7.3.2
- vitest: ^4.1.0 → ^4.1.4

No major version bumps (marked 18, vite 8, typescript 6, @vitejs/plugin-react 6 all skipped as major versions).

Closes #28, Closes #33